### PR TITLE
fix: cannot build if current branch is set

### DIFF
--- a/main.js
+++ b/main.js
@@ -54,7 +54,7 @@ core.setOutput('dashmate-branch', dashmateBranch);
 
 // Set current branch/tag name
 let currentBranchName = process.env['GITHUB_HEAD_REF'];
-if (currentBranch !== '') {
+if (currentBranchName !== '') {
   currentBranchName = process.env['GITHUB_REF'].replace(/\/refs\/tags\//, '');
   
   core.info(`Current tag name is ${currentBranchName}`);

--- a/main.js
+++ b/main.js
@@ -56,8 +56,8 @@ core.setOutput('dashmate-branch', dashmateBranch);
 
 let currentBranchName = process.env['GITHUB_HEAD_REF'];
 console.log(`currentBranchName is ${process.env['GITHUB_HEAD_REF']}`);
-if (currentBranchName !== undefined) {
-  console.log('currentBranchName is not undefined');
+if (currentBranchName === undefined) {
+  console.log('currentBranchName is undefined');
   currentBranchName = process.env['GITHUB_REF'].replace(/\/refs\/tags\//, '');
   
   core.info(`Current tag name is ${currentBranchName}`);

--- a/main.js
+++ b/main.js
@@ -53,13 +53,9 @@ if (overrideDashmateBranch !== undefined) {
 core.setOutput('dashmate-branch', dashmateBranch);
 
 // Set current branch/tag name
-console.dir(process.env);
 let currentBranchName = process.env['GITHUB_HEAD_REF'];
-console.log(`currentBranchName is ${process.env['GITHUB_HEAD_REF']}`);
-if (currentBranchName !== undefined) {
-  console.log('in currentBranchName condition')
+if (currentBranch !== '') {
   currentBranchName = process.env['GITHUB_REF'].replace(/\/refs\/tags\//, '');
-  console.log(`currentBranchName is ${currentBranchName}`);
   
   core.info(`Current tag name is ${currentBranchName}`);
 } else {

--- a/main.js
+++ b/main.js
@@ -55,7 +55,9 @@ core.setOutput('dashmate-branch', dashmateBranch);
 // Set current branch/tag name
 
 let currentBranchName = process.env['GITHUB_HEAD_REF'];
+console.log(`currentBranchName is ${process.env['GITHUB_HEAD_REF']}`);
 if (currentBranchName !== undefined) {
+  console.log('currentBranchName is not undefined');
   currentBranchName = process.env['GITHUB_REF'].replace(/\/refs\/tags\//, '');
   
   core.info(`Current tag name is ${currentBranchName}`);

--- a/main.js
+++ b/main.js
@@ -31,9 +31,9 @@ const overrideTestSuiteBranch = core.getInput('override-testsuite-branch') || un
 const testSuiteBranch = overrideTestSuiteBranch || platformBranch;
 
 if (overrideTestSuiteBranch !== undefined) {
-  console.log(`Test Suite branch overridden with ${overrideTestSuiteBranch}`);
+  core.info(`Test Suite branch overridden with ${overrideTestSuiteBranch}`);
 } else {
-  console.log(`Test Suite branch is ${testSuiteBranch}`);
+  core.info(`Test Suite branch is ${testSuiteBranch}`);
 }
 
 core.setOutput('testsuite-branch', testSuiteBranch);
@@ -45,18 +45,21 @@ const overrideDashmateBranch = core.getInput('override-dashmate-branch') || unde
 const dashmateBranch = overrideDashmateBranch || platformBranch;
 
 if (overrideDashmateBranch !== undefined) {
-  console.log(`Dashmate branch overridden with ${overrideDashmateBranch}`);
+  core.info(`Dashmate branch overridden with ${overrideDashmateBranch}`);
 } else {
-  console.log(`Dashmate branch is ${dashmateBranch}`);
+  core.info(`Dashmate branch is ${dashmateBranch}`);
 }
 
 core.setOutput('dashmate-branch', dashmateBranch);
 
 // Set current branch/tag name
-
+console.dir(process.env);
 let currentBranchName = process.env['GITHUB_HEAD_REF'];
-if (currentBranchName === undefined) {
+console.log(`currentBranchName is ${process.env['GITHUB_HEAD_REF']}`);
+if (currentBranchName !== undefined) {
+  console.log('in currentBranchName condition')
   currentBranchName = process.env['GITHUB_REF'].replace(/\/refs\/tags\//, '');
+  console.log(`currentBranchName is ${currentBranchName}`);
   
   core.info(`Current tag name is ${currentBranchName}`);
 } else {

--- a/main.js
+++ b/main.js
@@ -55,9 +55,7 @@ core.setOutput('dashmate-branch', dashmateBranch);
 // Set current branch/tag name
 
 let currentBranchName = process.env['GITHUB_HEAD_REF'];
-console.log(`currentBranchName is ${process.env['GITHUB_HEAD_REF']}`);
 if (currentBranchName === undefined) {
-  console.log('currentBranchName is undefined');
   currentBranchName = process.env['GITHUB_REF'].replace(/\/refs\/tags\//, '');
   
   core.info(`Current tag name is ${currentBranchName}`);


### PR DESCRIPTION
Setting `currentBranch` causes `gh-action-start-local-network` to pull drive from the upstream repo instead of my repo. I think it is because [this condition shouldn't pass](https://github.com/dashevo/gh-action-start-local-network/blob/master/bin/start-local-node.sh#L64). Is this intended behaviour? What does `currentBranch` refer to here and why does it need to be set? Is `currentBranch` always with reference to the current repo, or is it the upstream branch/repo? What should it be set to if building from a release trigger?

Inverting the logic here fixes my build, but I don't understand why.