### PR TITLE
fix: cache code is no longer needed

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,10 +11,6 @@ inputs:
   override-dashmate-branch:
     description: 'Override dashmate branch'
 outputs:
-  cache-url:
-    description: 'Cache url'
-  cache-token:
-    description: 'Cache token'
   testsuite-branch:
     description: 'Platform test suite branch'
   dashmate-branch:

--- a/main.js
+++ b/main.js
@@ -1,11 +1,6 @@
 const core = require('@actions/core');
 const getBranchFromVersion = require('./src/getBranchFromVersion');
 
-// Set action/cache variables to use in other steps
-
-core.setOutput('cache-url', process.env.ACTIONS_CACHE_URL);
-core.setOutput('cache-token', process.env.ACTIONS_RUNTIME_TOKEN);
-
 // Get compatible platform branch name
 
 const { version } = require(`${process.env.GITHUB_WORKSPACE}/package.json`);


### PR DESCRIPTION
This PR removes cache outputs from the action, which are no longer needed due to a change in caching approach.