### PR TITLE
fix: incorrect parsing of github.ref on workflow_dispatch

### DIFF
--- a/main.js
+++ b/main.js
@@ -57,16 +57,14 @@ core.setOutput('dashmate-branch', dashmateBranch);
 let currentBranchName;
 if (process.env.GITHUB_EVENT_NAME === 'pull_request') {
   currentBranchName = process.env.GITHUB_HEAD_REF;
-
-  core.info(`Current branch name is ${currentBranchName}`);
-} else if (process.env.GITHUB_EVENT_NAME === 'workflow_dispatch') {
-  currentBranchName = process.env.GITHUB_REF.substring('refs/heads/'.length);
-
   core.info(`Current branch name is ${currentBranchName}`);
 } else {
-  currentBranchName = process.env.GITHUB_REF.substring('refs/tags/'.length);
-
-  core.info(`Current tag name is ${currentBranchName}`);
+  let refType = 'tags';
+  if (process.env.GITHUB_EVENT_NAME === 'workflow_dispatch') {
+     refType = 'heads';
+  }
+  currentBranchName = process.env.GITHUB_REF.substring(`refs/${refType}/`.length);
+  core.info(`Current branch name is ${currentBranchName}`);
 }
 
 core.setOutput('current-branch', currentBranchName);

--- a/main.js
+++ b/main.js
@@ -60,6 +60,7 @@ if (process.env.GITHUB_EVENT_NAME === 'pull_request') {
 
   core.info(`Current branch name is ${currentBranchName}`);
 } else {
+  core.info(`Current ref is ${ process.env.GITHUB_REF }`);
   currentBranchName = process.env.GITHUB_REF.substring('refs/tags/'.length);
 
   core.info(`Current tag name is ${currentBranchName}`);

--- a/main.js
+++ b/main.js
@@ -61,6 +61,7 @@ if (process.env.GITHUB_EVENT_NAME === 'pull_request') {
   core.info(`Current branch name is ${currentBranchName}`);
 } else {
   core.info(`Current ref is ${ process.env.GITHUB_REF }`);
+  core.info(`GitHub event name is ${ process.env.GITHUB_EVENT_NAME }`)
   currentBranchName = process.env.GITHUB_REF.substring('refs/tags/'.length);
 
   core.info(`Current tag name is ${currentBranchName}`);

--- a/main.js
+++ b/main.js
@@ -59,8 +59,9 @@ if (process.env.GITHUB_EVENT_NAME === 'pull_request') {
   currentBranchName = process.env.GITHUB_HEAD_REF;
 
   core.info(`Current branch name is ${currentBranchName}`);
-} else {
+} else if (process.env.GITHUB_EVENT_NAME === 'workflow_dispatch') {
   core.info(`Current ref is ${ process.env.GITHUB_REF }`);
+  core.info(`Current head ref is ${ process.env.GITHUB_HEAD_REF }`);
   core.info(`GitHub event name is ${ process.env.GITHUB_EVENT_NAME }`)
   currentBranchName = process.env.GITHUB_REF.substring('refs/tags/'.length);
 

--- a/main.js
+++ b/main.js
@@ -60,9 +60,10 @@ if (process.env.GITHUB_EVENT_NAME === 'pull_request') {
 
   core.info(`Current branch name is ${currentBranchName}`);
 } else if (process.env.GITHUB_EVENT_NAME === 'workflow_dispatch') {
-  core.info(`Current ref is ${ process.env.GITHUB_REF }`);
-  core.info(`Current head ref is ${ process.env.GITHUB_HEAD_REF }`);
-  core.info(`GitHub event name is ${ process.env.GITHUB_EVENT_NAME }`)
+  currentBranchName = process.env.GITHUB_REF.substring('refs/heads/'.length);
+
+  core.info(`Current branch name is ${currentBranchName}`);
+} else {
   currentBranchName = process.env.GITHUB_REF.substring('refs/tags/'.length);
 
   core.info(`Current tag name is ${currentBranchName}`);


### PR DESCRIPTION
This PR:
- adds logic to detect workflows triggered by `workflow_dispatch` and parse the `github.ref` correctly

Test run with debug output: https://github.com/dashevo/js-drive/runs/2960764803?check_suite_focus=true
Working test run: https://github.com/dashevo/js-drive/runs/2960802191?check_suite_focus=true